### PR TITLE
Japanese translated Readme.md

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -89,17 +89,17 @@ Flutterを例にとって、4つのレイヤーがあり、メインのフォー
 
 ## External
 
-Here we implement the external accesses that depends on a hardware, package or highly-specific access.
+ここでは、ハードウェア、パッケージ、または高度に特定のアクセスに依存する外部アクセスを実装します。
 
-Basically, the **External** layer must contain everything that is expected to be highly volatile and constantly changed.
+基本的に、**External** レイヤーには、非常に揮発性が高く、常に変化することが期待されるすべてが含まれます。
 
-In Flutter, for instance, we use `shared_preferences` for local cache. However, it may be that, in a later stage of the project, `shared_preferences` won't be able to meet the requirements of our application and we will want to replace it with another package, like `hive`. When this happens, all we need to do is to implement, using the logic inherent to `hive`, a new instance of the contract that the infrastructure layer expects.
+Flutterにおいて、例えば、ローカルキャッシュには `shared_preferences` を使用します。しかし、プロジェクトの後半になると、`shared_preferences` がアプリケーションの要件を満たすことができなくなり、`hive` のような別のパッケージに置き換えたいと思うかもしれません。この場合、必要なのは、`hive` 固有のロジックを使用して、インフラストラクチャレイヤーが期待する契約の新しいインスタンスを実装するだけです。
 
-Another pragmatic example would be to think in a login system based on Firebase Auth. Another product, however, want to use other authentication provider. To make this substitution it would be as simple as implementing a data source based on this new provider and "invert the dependency", using this implementation instead of the Firebase one's when need.
+他の実用的な例は、Firebase Auth を元としたログインシステムを考える時です。しかしながら、他の認証プロバイダを使用したいと思う別の製品があります。この置換を行うためには、新しいプロバイダに基づいたデータソースを実装し、必要に応じてこの実装を使用するだけです。この代用を行うには、この新しいプロバイダに基づいたデータソースの実装をし、必要な時にFirebaseのものの代わりにこの実装を使用する「依存関係の反転」を行うだけで良くなります。
 
-The **data sources** must only worry about discovering the external data and sending it to the infra layer, where they will be dealt.
+**データソース** は、外部データを発見し、それをインフラレイヤーに送信することだけに気を配らなければなりません。
 
-Likewise, the **drivers** objects must only provide the device hardware info that is required by the contract, and not deal with anything else.
+これと同様に、**ドライバー** オブジェクトは、契約で必要とされるデバイスハードウェア情報のみを提供し、それ以外のことには関与してはいけません。
 
 # Tips
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -35,10 +35,9 @@ If an **use case** needs to access a higher layer, it should be done with the [*
 
 もし **ユースケース** が上位レイヤーにアクセスする必要がある場合、それは [**依存性逆転の原則**](https://ja.wikipedia.org/wiki/%E4%BE%9D%E5%AD%98%E6%80%A7%E9%80%86%E8%BB%A2%E3%81%AE%E5%8E%9F%E5%89%87) を考慮して行われるべきです。
 
-## Interface Adapters
+## Interface Adapters : 異なるレイヤーをつなげる適合器
 
-This layer is responsible for acting as a bridge between the higher layers and the external data. It helps the external data to communicate with the higher layers in a way that respects the interface contracts defined in the business rules.
-
+このレイヤーは、上位レイヤーと外部データの間の橋渡しとしての役割を果たします。これは、ビジネスルールで定義されたインターフェース契約を尊重する方法で、外部データが上位レイヤーと通信するのを助けます。
 
 ## Frameworks & Drivers
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,5 +1,5 @@
 # Clean Dart
-Clean architecture proposal for Dart/Flutter.
+Dart/Flutter向けのクリーンアーキテクチャ提案
 
 # Introduction
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -59,9 +59,9 @@ Flutterを例にとって、4つのレイヤーがあり、メインのフォー
 
 ## Presenter
 
-The **Presenter** layer is responsible to declare the I/O and the interactions of the application.
+**プレゼンター** レイヤーは、アプリケーションのI/Oと相互作用を宣言する責任があります。
 
-If we take Flutter as an example, this layer would contain the Widgets, Pages and the State Management. On the other hand, if we were dealing with the backend, this layer would be where we would have the Handlers or Commands of our API.
+もし、Flutterを例にとると、このレイヤーには、ウィジェット、ページ、およびステート管理が含まれます。一方、バックエンドを扱う場合、このレイヤーはAPIのハンドラーやコマンドが存在する場所になります。
 
 ## Domain
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -117,10 +117,10 @@ Flutterにおいて、例えば、ローカルキャッシュには `shared_pref
 
 ## Spent your time dealing with possible errors
 
-**It's better to let a Exception be thrown than to handle it in a generic way...**
-A good tip is to use some handling-enforcing approach, like the `Either` class from `dartz` library.
+**一般的に例外を処理するよりも例外をスローさせる方が良いです...**
+良いアプローチは、`dartz` ライブラリの `Either` クラスのようなハンドリング強制アプローチを使用することです。
 
-The `Either` class may receive two distinct data, a `Left` one, representing an error, and a `Right` one, representing the actual expected result. This reduces a lot the need to manually handle the exceptions with **try-catch**, which is error-prone, in higher layers.
+`Either` クラスは、2つの異なるデータを受け取ることができます。`Left` はエラーを表し、`Right` は実際の期待される結果を表します。これにより、例外を手動で **try-catch** で処理する必要がなくなり、エラーが発生しやすい上位レイヤーでの処理が減ります。
 
 ## Don't fall in the temptation of bypassing a layer
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -25,13 +25,15 @@ Dart/Flutter向けのクリーンアーキテクチャ提案
 
 エンティティは、純粋でなければなりません。これは、それが下のレイヤーについての知識を持っていないことを意味します。一方、他のすべてのレイヤーは、**エンティティ**について知っています。
 
-## Application Business Rules
+## Application Business Rules : コンピュータ上のプログラムの就業規則
 
-They are the rules that are exclusive and specific to your application and can only be executed by the target device. They are expressed in commands called **use cases**, which, roughly speaking, represents any action the user can perform within your application.
+これらは、排他的で特定のアプリケーションに固有のルールであり、ターゲットデバイスでのみ実行できます。これらは、**ユースケース** と呼ばれるコマンドで表され、大まかに言えば、ユーザーがアプリケーション内で実行できるアクションを表します。
 
-An **use case** only knows the **entities** layer, and know nothing about the lower layers.
+**ユースケース** は、**エンティティ** レイヤーのみを知っており、下位レイヤーについては何も知りません。
 
 If an **use case** needs to access a higher layer, it should be done with the [**Dependency Inversion Principle**](https://en.wikipedia.org/wiki/Dependency_inversion_principle) in mind.
+
+もし **ユースケース** が上位レイヤーにアクセスする必要がある場合、それは [**依存性逆転の原則**](https://ja.wikipedia.org/wiki/%E4%BE%9D%E5%AD%98%E6%80%A7%E9%80%86%E8%BB%A2%E3%81%AE%E5%8E%9F%E5%89%87) を考慮して行われるべきです。
 
 ## Interface Adapters
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -77,15 +77,15 @@ Flutterを例にとって、4つのレイヤーがあり、メインのフォー
 
 ## Infrastructure (Infra)
 
-This layer supports the **Domain** layer by implementing its interfaces. To do this, it have to adapt the external data so that it fullfill the domain contracts.
+このレイヤーは、インターフェースを実装することで **ドメイン** レイヤーをサポートします。これを行うために、外部データを適応させ、ドメインの契約を満たす必要があります。
 
-This layer will, probably, have the implementation for some repository or service interface that can't depend on external data, like an API, or the access to some hardware, like a Bluetooth device.
+このレイヤーには、おそらく、APIなどの外部データに依存できないリポジトリやサービスインターフェースの実装や、Bluetoothデバイスなどのハードウェアへのアクセスが含まれます。
 
-For the repository to be able to process and adapt the external data we must create contracts for these services, aiming to defer the implementation responsibility to a lower-level layer in our architecture.
+リポジトリが外部データを処理し適応できるようにするために、これらのサービスのための契約を作成する必要があります。これは、我々のアーキテクチャの下位レイヤーに実装責任を遅延させることを目的としています。
 
-Our suggestion is to create **DataSource** object when we want to access external data, that is, for example, a BaaS like Firebase or a SQLite-based local cache. Another suggestion is to create **Driver** objects to interface the communication between your application and some device hardware.
+私たちの提案は、外部データにアクセスするために **DataSource** オブジェクトを作成することです。例えば、FirebaseのようなBaaSや、SQLiteベースのローカルキャッシュです。また、アプリケーションとデバイスハードウェアの間の通信をインターフェースするために **Driver** オブジェクトを作成することも提案しています。
 
-The external accesses like data sources and drivers must be implemented by another layer, leaving only the interface contracts in this layer.
+データソースとドライバーのような外部アクセスは、別のレイヤーによって実装されなければならず、このレイヤーにはインターフェース契約のみが残ります。
 
 ## External
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -31,8 +31,6 @@ Dart/Flutter向けのクリーンアーキテクチャ提案
 
 **ユースケース** は、**エンティティ** レイヤーのみを知っており、下位レイヤーについては何も知りません。
 
-If an **use case** needs to access a higher layer, it should be done with the [**Dependency Inversion Principle**](https://en.wikipedia.org/wiki/Dependency_inversion_principle) in mind.
-
 もし **ユースケース** が上位レイヤーにアクセスする必要がある場合、それは [**依存性逆転の原則**](https://ja.wikipedia.org/wiki/%E4%BE%9D%E5%AD%98%E6%80%A7%E9%80%86%E8%BB%A2%E3%81%AE%E5%8E%9F%E5%89%87) を考慮して行われるべきです。
 
 ## Interface Adapters : 異なるレイヤーをつなげる適合器

--- a/README_ja.md
+++ b/README_ja.md
@@ -124,13 +124,13 @@ Flutterにおいて、例えば、ローカルキャッシュには `shared_pref
 
 ## Don't fall in the temptation of bypassing a layer
 
-Sometimes you may have a very simple **usecase**, that will simply pass the data to the **repository**, like, for example, a CRUD where all you need to do is to validate if the data is being correctly received and yield it to the **repository** to do its work.
+時々、とてもシンプルな **ユースケース** があるかもしれません。例えば、これはデータが正しく受信されていることを確認し、CRUD処理を行うためにデータを **リポジトリ** に渡すだけのものです。
 
-It may seem weird to have a class that have a single method which only function is to validate the data and send it to another class, but you are going to see that this will become quite useful when you are maintaining your project. It's not uncommon that your **usecase** borns small like this, but in the near future it grows bigger and more complex.
+データを検証して、別のクラスに送信するだけのメソッドを持つクラスがあることは、奇妙に思えるかもしれませんが、プロジェクトを保守する際に非常に便利であることがわかります。あなたの **ユースケース** がこのように小さく生まれることは珍しくありませんが、近い将来にはより大きく、より複雑になります。
 
-An example of this case is when you are using Firebase. The Firebase package only returns a Stream, and you could, as well, simply put it directly in your **view**. However, if someday you need to remove Firebase from your project and replace it with an alternative, you will have to remake your entire view, or even your entire project.
+この場合の一つの例としては、Firebaseを使う時です。Firebaseパッケージは単にStreamを返すだけで、あなたは同様にそれを直接あなたの **ビュー** に置くことができます。しかし、いつかFirebaseをプロジェクトから削除して代替手段に置き換える必要がある場合、ビュー全体を作り直すか、プロジェクト全体を作り直す必要があるかもしれません。
 
-That said, don't fall in the temptation of calling the **repository** directly from your **controller**, or to use Firebase directly in your **view**. You will be breaking your architecture laws and will eventually regret of your decision.
+つまり、あなたの **コントローラ** から直接 **リポジトリ** を呼び出すこと、またはFirebaseを直接 **ビュー** で使用することに誘惑されないでください。あなたはあなたのアーキテクチャの法則を破り、最終的にはあなたの決定を後悔することになります。
 
 # Sign up!
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -3,9 +3,9 @@ Dart/Flutter向けのクリーンアーキテクチャ提案
 
 # Introduction
 
-We can say that a clean architecture might define the future of your project. Knowing that, it's our role to study constantly in order to know where, when and how to apply it.
+クリーンアーキテクチャは、プロジェクトの未来を定義すると言えます。そのため、私たちの役割は、それをどこに、いつ、どのように適用するかを知るために、常に勉強することです。
 
-This proposal is based on Robert C. Martin's **“Clean Architecture: A Craftsman's Guide to Software Structure and Design”** principles and it's layers structure approach.
+この提案は、Robert C. Martinの **“Clean Architecture: A Craftsman's Guide to Software Structure and Design”** の原則と、そのレイヤー構造アプローチに基づいています。
 
 # Clean Architecture layers
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -51,11 +51,11 @@ Rest APIからGraphQL APIに、UIから別のUIに、FlutterからAngularDartに
 
 ![Image 1](imgs/img1.png)
 
-By using Flutter as an example, we have four layers, keeping the "plugin architecture", with the main focus on the Application Domain. In this layer inhabits the two main business rules, the **entities** and the **usecases**.
+Flutterを例にとって、4つのレイヤーがあり、メインのフォーカスはアプリケーションドメインにあります。このレイヤーには、2つの主要なビジネスルール、**エンティティ** と **ユースケース** が存在します。
 
 ![Image 1](imgs/img2.png)
 
-This architecture proposes to dissociate the external layers and preserve the business rules.
+このアーキテクチャは、外部レイヤーを分離し、ビジネスルールを保持することを提案しています。
 
 ## Presenter
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -111,9 +111,9 @@ Flutterにおいて、例えば、ローカルキャッシュには `shared_pref
 
 ## Unit Testing is your new UI
 
-It's very common to developers to create your apps views before anything, so they help them to test their business rules. However, we already have a more proper tool for this, and a place specially designed for this kind of test.
+なにを始める前にも、アプリケーションのビューを作成することは、開発者にとって非常に一般的で、ビジネスルールをテストするのに役立ちます。しかし、これに対してより適切なツールがすでに存在し、特にこの種のテストに特化した場所があります。
 
-Developing in a "clean" way is completely related with **TDD** (Test-Driven Development), as the **Presenter** layer is going to be one of the latest that we are going to think and develop.
+"クリーン" な方法で開発することは、**TDD** (テスト駆動開発) と完全に関連しており、**プレゼンター** レイヤーは、最後に考えて開発するものの1つになります。
 
 ## Spent your time dealing with possible errors
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -19,11 +19,11 @@ Dart/Flutter向けのクリーンアーキテクチャ提案
 ![Image 3](imgs/img3.png)
 
 
-## Enterprise Business Rules
+## Enterprise Business Rules : 企業の就業規則
 
-They are the most sensitive rules of a system and, thus, the highest-level layer. They are represented by data models called **entities**. 
+これは、システムの最も感度が高く、最も高いレベルのレイヤーです。これらは、**エンティティ**と呼ばれるデータモデルによって表されます。
 
-An **entity** must be pure. This means that it cannot have any knowledge about the layers below it. On the other hand, all other layers know about the **entities**.
+エンティティは、純粋でなければなりません。これは、それが下のレイヤーについての知識を持っていないことを意味します。一方、他のすべてのレイヤーは、**エンティティ**について知っています。
 
 ## Application Business Rules
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -134,12 +134,15 @@ Flutterにおいて、例えば、ローカルキャッシュには `shared_pref
 
 # Sign up!
 
-We would like to have your feedback!
+私たちはあなたのフィードバックを待っています！
 
-If you like your "Clean Dart" architecture proposal, leave a **star** in this repository. This is the same as signing a "clean manifest" agreeing with our proposal!
+もし、あなたがこの提案に賛成であるなら、このリポジトリに **スター** をつけてください。これは、私たちの提案に同意する「クリーンマニフェスト」に署名することと同じです！
 
 We are open to suggestions and improvements on this documentation!
 If you want to contribute, open an [issue](https://github.com/Flutterando/Clean-Dart/issues). Our team will be very happy with your interest in improving this tool for the community. Also, feel free to open a **pull request** with fixes to this proposal documentation.
+
+私たちはこのドキュメントに関する提案と改善を受け付けています！
+もし、貢献したいと思ったら、[issue](https://github.com/Flutterando/Clean-Dart/issues)を開いてください。私たちのチームは、コミュニティのためにこのツールを改善するためのあなたの関心に非常に喜びます。また、この提案のドキュメントを修正するための **プルリクエスト** を自由に開いてください。
 
 # Examples
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,161 @@
+# Clean Dart
+Clean architecture proposal for Dart/Flutter.
+
+# Introduction
+
+We can say that a clean architecture might define the future of your project. Knowing that, it's our role to study constantly in order to know where, when and how to apply it.
+
+This proposal is based on Robert C. Martin's **“Clean Architecture: A Craftsman's Guide to Software Structure and Design”** principles and it's layers structure approach.
+
+# Clean Architecture layers
+
+**Robert C. Martin** states that, to be considered "clean", an architecture must have at least 4 main and independent layers. They are:
+
+1. Enterprise Business Rules
+2. Application Business Rules
+3. Interface Adapters
+4. Frameworks & Drivers (External)
+
+![Image 3](imgs/img3.png)
+
+
+## Enterprise Business Rules
+
+They are the most sensitive rules of a system and, thus, the highest-level layer. They are represented by data models called **entities**. 
+
+An **entity** must be pure. This means that it cannot have any knowledge about the layers below it. On the other hand, all other layers know about the **entities**.
+
+## Application Business Rules
+
+They are the rules that are exclusive and specific to your application and can only be executed by the target device. They are expressed in commands called **use cases**, which, roughly speaking, represents any action the user can perform within your application.
+
+An **use case** only knows the **entities** layer, and know nothing about the lower layers.
+
+If an **use case** needs to access a higher layer, it should be done with the [**Dependency Inversion Principle**](https://en.wikipedia.org/wiki/Dependency_inversion_principle) in mind.
+
+## Interface Adapters
+
+This layer is responsible for acting as a bridge between the higher layers and the external data. It helps the external data to communicate with the higher layers in a way that respects the interface contracts defined in the business rules.
+
+
+## Frameworks & Drivers
+
+All the higher-level layers abstractions were designed specially top improve the decoupling between them and the external artifacts. This makes easier to switch them whenever you want, in a plug & play fashion.
+
+The frameworks & drivers layer is highly volatile, and is constantly changing. Within a clean architecture, however, these changes may be completely painless and safe, leaving your business rules untouched.
+
+We can, then, switch from our Rest API to a GraphQL one, from our UI to another one, or even from Flutter itself to AngularDart. The business rules will keep working as before, as you won't need to change them not even a little.
+
+That said, let's present our proposal for a Flutterando Clean Architecture, namely, **Clean Dart**.
+
+
+# Clean Dart
+
+![Image 1](imgs/img1.png)
+
+By using Flutter as an example, we have four layers, keeping the "plugin architecture", with the main focus on the Application Domain. In this layer inhabits the two main business rules, the **entities** and the **usecases**.
+
+![Image 1](imgs/img2.png)
+
+This architecture proposes to dissociate the external layers and preserve the business rules.
+
+## Presenter
+
+The **Presenter** layer is responsible to declare the I/O and the interactions of the application.
+
+If we take Flutter as an example, this layer would contain the Widgets, Pages and the State Management. On the other hand, if we were dealing with the backend, this layer would be where we would have the Handlers or Commands of our API.
+
+## Domain
+
+The **Domain** layer will contain our **core business rules** (entity) and **application-specific business rules** (usecases).
+
+Our **entities** must be simple objects, that may or not have validation rules for its data through functions or ValueObjects. **The entity must not depend on any object of the other layers.**
+
+The **usecases** must run the necessary logic to solve a specific problem. If the **usecase** needs the any external access, this access may be done through interface contacts that will be implemented by the lower-level layers.
+
+The **Domain** must be responsible only for the execution of the business rules. It must not have any other object implementations, like repositories or services.
+
+Taking a repository as example, we will have only the interface contract to this repository. The implementation of this contract must be done by a lower-level layer.
+
+## Infrastructure (Infra)
+
+This layer supports the **Domain** layer by implementing its interfaces. To do this, it have to adapt the external data so that it fullfill the domain contracts.
+
+This layer will, probably, have the implementation for some repository or service interface that can't depend on external data, like an API, or the access to some hardware, like a Bluetooth device.
+
+For the repository to be able to process and adapt the external data we must create contracts for these services, aiming to defer the implementation responsibility to a lower-level layer in our architecture.
+
+Our suggestion is to create **DataSource** object when we want to access external data, that is, for example, a BaaS like Firebase or a SQLite-based local cache. Another suggestion is to create **Driver** objects to interface the communication between your application and some device hardware.
+
+The external accesses like data sources and drivers must be implemented by another layer, leaving only the interface contracts in this layer.
+
+## External
+
+Here we implement the external accesses that depends on a hardware, package or highly-specific access.
+
+Basically, the **External** layer must contain everything that is expected to be highly volatile and constantly changed.
+
+In Flutter, for instance, we use `shared_preferences` for local cache. However, it may be that, in a later stage of the project, `shared_preferences` won't be able to meet the requirements of our application and we will want to replace it with another package, like `hive`. When this happens, all we need to do is to implement, using the logic inherent to `hive`, a new instance of the contract that the infrastructure layer expects.
+
+Another pragmatic example would be to think in a login system based on Firebase Auth. Another product, however, want to use other authentication provider. To make this substitution it would be as simple as implementing a data source based on this new provider and "invert the dependency", using this implementation instead of the Firebase one's when need.
+
+The **data sources** must only worry about discovering the external data and sending it to the infra layer, where they will be dealt.
+
+Likewise, the **drivers** objects must only provide the device hardware info that is required by the contract, and not deal with anything else.
+
+# Tips
+
+## Think on layers
+
+When you are about to start developing, start thinking about layers. We shouldn't worry with what the **Presenter** or **External** layers have, for example. If we start thinking by the external layers we may be eventually misguided by them. Thus, we should get used to develop each layer, from the most internal to the most external.
+
+It may be that, in the beginning of your "clean" journey, some of these layers may seem useless. This happens when our thinking is not yet based **on layers** (or, maybe, because your business rule is too much simple for this).
+
+## Unit Testing is your new UI
+
+It's very common to developers to create your apps views before anything, so they help them to test their business rules. However, we already have a more proper tool for this, and a place specially designed for this kind of test.
+
+Developing in a "clean" way is completely related with **TDD** (Test-Driven Development), as the **Presenter** layer is going to be one of the latest that we are going to think and develop.
+
+## Spent your time dealing with possible errors
+
+**It's better to let a Exception be thrown than to handle it in a generic way...**
+A good tip is to use some handling-enforcing approach, like the `Either` class from `dartz` library.
+
+The `Either` class may receive two distinct data, a `Left` one, representing an error, and a `Right` one, representing the actual expected result. This reduces a lot the need to manually handle the exceptions with **try-catch**, which is error-prone, in higher layers.
+
+## Don't fall in the temptation of bypassing a layer
+
+Sometimes you may have a very simple **usecase**, that will simply pass the data to the **repository**, like, for example, a CRUD where all you need to do is to validate if the data is being correctly received and yield it to the **repository** to do its work.
+
+It may seem weird to have a class that have a single method which only function is to validate the data and send it to another class, but you are going to see that this will become quite useful when you are maintaining your project. It's not uncommon that your **usecase** borns small like this, but in the near future it grows bigger and more complex.
+
+An example of this case is when you are using Firebase. The Firebase package only returns a Stream, and you could, as well, simply put it directly in your **view**. However, if someday you need to remove Firebase from your project and replace it with an alternative, you will have to remake your entire view, or even your entire project.
+
+That said, don't fall in the temptation of calling the **repository** directly from your **controller**, or to use Firebase directly in your **view**. You will be breaking your architecture laws and will eventually regret of your decision.
+
+# Sign up!
+
+We would like to have your feedback!
+
+If you like your "Clean Dart" architecture proposal, leave a **star** in this repository. This is the same as signing a "clean manifest" agreeing with our proposal!
+
+We are open to suggestions and improvements on this documentation!
+If you want to contribute, open an [issue](https://github.com/Flutterando/Clean-Dart/issues). Our team will be very happy with your interest in improving this tool for the community. Also, feel free to open a **pull request** with fixes to this proposal documentation.
+
+# Examples
+
+- [Clean Dart Login with Firebase, MobX and Modular](https://github.com/jacobaraujo7/login-firebase-clean-dart)
+- [Clean Dart Github Search with BLoC and Modular](https://github.com/Flutterando/clean-dart-search-bloc)
+- [Clean Dart Github Search with MobX and Modular](https://github.com/jacobaraujo7/clean-dart-search-mobx)
+- [Clean Dart Github Search with Flutter Command](https://github.com/aquilarafa/clean_dart_flutter_command)
+- [Chat WebSocket with Get_It and Cubit](https://github.com/rodrigorahman/flutter_curso_chat_websocket)
+- [Clean Dart Pokedex with BLoC and Modular](https://github.com/umpedetiago/pokedex_with_cleandart.git) 
+
+# Useful links
+
+- [Resumo do livro "Arquitetura Limpa"](https://medium.com/@deividchari/desvendando-a-arquitetura-limpa-de-uncle-bob-3e60d9aa9cce)
+- [Sua Arquitetura está limpa?](https://medium.com/flutterando/sua-arquitetura-est%C3%A1-limpa-clean-architecture-no-flutter-458c68fad120)
+- [Os tijolos do Clean Architecture](https://www.youtube.com/watch?v=C8mpy3pwqQc)
+- [The Clean Code Blog](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
+- [Guilherme's Proposal](https://github.com/guilherme-v/flutter-clean-arch)

--- a/README_ja.md
+++ b/README_ja.md
@@ -9,12 +9,12 @@ Dart/Flutter向けのクリーンアーキテクチャ提案
 
 # Clean Architecture layers
 
-**Robert C. Martin** states that, to be considered "clean", an architecture must have at least 4 main and independent layers. They are:
+**Robert C. Martin**は、アーキテクチャが「クリーン」であるためには、少なくとも4つの主要かつ独立したレイヤーを持っている必要があると述べています。それらは次のとおりです。
 
-1. Enterprise Business Rules
-2. Application Business Rules
-3. Interface Adapters
-4. Frameworks & Drivers (External)
+1. Enterprise Business Rules : 企業の就業規則
+2. Application Business Rules : コンピュータ上のプログラムの就業規則
+3. Interface Adapters : 異なるレイヤーをつなげる適合器
+4. Frameworks & Drivers (External) : プログラムの枠組みとOSとDevice間のソフトウェア（外部）
 
 ![Image 3](imgs/img3.png)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -39,16 +39,15 @@ If an **use case** needs to access a higher layer, it should be done with the [*
 
 このレイヤーは、上位レイヤーと外部データの間の橋渡しとしての役割を果たします。これは、ビジネスルールで定義されたインターフェース契約を尊重する方法で、外部データが上位レイヤーと通信するのを助けます。
 
-## Frameworks & Drivers
+## Frameworks & Drivers (External) : プログラムの枠組みとOSとDevice間のソフトウェア（外部）
 
-All the higher-level layers abstractions were designed specially top improve the decoupling between them and the external artifacts. This makes easier to switch them whenever you want, in a plug & play fashion.
+全ての上位レイヤーの抽象化は、それらと外部アーティファクトとの間の結合を改善するために特に設計されました。これにより、プラグ＆プレイのスタイルでいつでもそれらを切り替えることが容易になります。
 
-The frameworks & drivers layer is highly volatile, and is constantly changing. Within a clean architecture, however, these changes may be completely painless and safe, leaving your business rules untouched.
+このレイヤーは非常に揮発性が高く、常に変化しています。しかし、クリーンアーキテクチャの中では、これらの変更は完全に痛みなく安全に行うことができ、ビジネスルールは変更されません。
 
-We can, then, switch from our Rest API to a GraphQL one, from our UI to another one, or even from Flutter itself to AngularDart. The business rules will keep working as before, as you won't need to change them not even a little.
+Rest APIからGraphQL APIに、UIから別のUIに、FlutterからAngularDartに切り替えることができます。ビジネスルールは以前と同じように機能し続け、それらを変更する必要はありません。
 
-That said, let's present our proposal for a Flutterando Clean Architecture, namely, **Clean Dart**.
-
+そうは言っても、具体例がないと理解が難しいかもしれません。そこで、Flutterando Clean Architecture、つまり **Clean Dart** の提案をご紹介します。
 
 # Clean Dart
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -65,15 +65,15 @@ Flutterを例にとって、4つのレイヤーがあり、メインのフォー
 
 ## Domain
 
-The **Domain** layer will contain our **core business rules** (entity) and **application-specific business rules** (usecases).
+**ドメイン** レイヤーは、**エンティティ** と **ユースケース** を含む **ビジネスルール** を持っています。
 
-Our **entities** must be simple objects, that may or not have validation rules for its data through functions or ValueObjects. **The entity must not depend on any object of the other layers.**
+**エンティティ** は、データの検証ルールや関数、または `ValueObjects` を通じてデータの検証ルールを持つかもしれませんが、シンプルなオブジェクトである必要があります。**エンティティは、他のレイヤーのオブジェクトに依存してはいけません。**
 
-The **usecases** must run the necessary logic to solve a specific problem. If the **usecase** needs the any external access, this access may be done through interface contacts that will be implemented by the lower-level layers.
+**ユースケース** は、特定の問題を解決するために必要なロジックを実行しなければなりません。もし **ユースケース** が外部アクセスを必要とする場合、このアクセスは、下位レイヤーによって実装されるインターフェースコンタクトを介して行われるかもしれません。
 
-The **Domain** must be responsible only for the execution of the business rules. It must not have any other object implementations, like repositories or services.
+**ドメイン** は、ビジネスルールの実行のみに責任を持たなければなりません。リポジトリやサービスのような他のオブジェクトの実装を持ってはいけません。
 
-Taking a repository as example, we will have only the interface contract to this repository. The implementation of this contract must be done by a lower-level layer.
+責任を持つ例として、リポジトリを取ると、このリポジトリにはインターフェース契約のみがあります。この契約の実装は、下位レイヤーによって行われなければなりません。
 
 ## Infrastructure (Infra)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -105,9 +105,9 @@ Flutterにおいて、例えば、ローカルキャッシュには `shared_pref
 
 ## Think on layers
 
-When you are about to start developing, start thinking about layers. We shouldn't worry with what the **Presenter** or **External** layers have, for example. If we start thinking by the external layers we may be eventually misguided by them. Thus, we should get used to develop each layer, from the most internal to the most external.
+開発を始める時、レイヤーについて考えることから始めましょう。例えば、**プレゼンター** や **外部** レイヤーについては心配しないでください。もし外部レイヤーから考え始めると、最終的にはそれに誤解されるかもしれません。したがって、最も内部から最も外部まで、各レイヤーを開発することに慣れるべきです。
 
-It may be that, in the beginning of your "clean" journey, some of these layers may seem useless. This happens when our thinking is not yet based **on layers** (or, maybe, because your business rule is too much simple for this).
+あなたの "クリーン" な旅の最初には、これらのレイヤーのいくつかが無駄に見えるかもしれません。これは、私たちの考え方がまだ **レイヤー** に基づいていない場合に起こります (または、おそらく、あなたのビジネスルールがこれに対してあまりにも単純すぎるためかもしれません)。
 
 ## Unit Testing is your new UI
 


### PR DESCRIPTION
# What I did
I created Japanese translated `Readme.md` as `Readme_ja.md`

# Objective

This document seems very helpful for developing Flutter (and any application even though you may not use Flutter).

Therefore, if this document supports a lot of language, I think more people can develop Flutter application with clean architecture!

